### PR TITLE
ci: Stricter pattern matching for image download

### DIFF
--- a/.github/workflows/publish-gardenlinux.yml
+++ b/.github/workflows/publish-gardenlinux.yml
@@ -91,7 +91,7 @@ jobs:
             | jq -r '.assets[].name')
 
           for ARCH in amd64 arm64; do
-            ASSET=$(echo "$ASSETS" | grep -E "^${{ matrix.asset_pattern }}-${ARCH}-.*\.tar\.xz$" | head -1)
+            ASSET=$(echo "$ASSETS" | grep -E "^${{ matrix.asset_pattern }}-${ARCH}-[0-9]+\.[0-9]+\.[0-9]+-[0-9a-f]+\.tar\.xz$" | head -1)
             if [ -z "$ASSET" ]; then
               echo "::error::Could not find asset matching ${{ matrix.asset_pattern }}-${ARCH}-*.tar.xz"
               exit 1


### PR DESCRIPTION
gardenlinux releases from 2150.1.0 [0] started including file <release>.logs.tar.xz in its artifacts. This file matched our pattern that searches for the image itself, causing our CI jobs to fail[1].

The new regexp should match only the image itself, disregarding logs, or any other additional artifact that might be included in the future.

[0] https://github.com/gardenlinux/gardenlinux/releases/tag/2150.1.0
[1] https://github.com/ironcore-dev/os-images/actions/runs/24617135043/job/71981127138